### PR TITLE
fix(release): clean before publish

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -8,7 +8,7 @@
     "@semantic-release/release-notes-generator",
     ["@semantic-release/exec", {
       "verifyConditionsCmd": "./gradlew signMavenJavaPublication",
-      "publishCmd": "./gradlew publishToSonatype closeSonatypeStagingRepository"
+      "publishCmd": "./gradlew clean publishToSonatype closeSonatypeStagingRepository"
     }],
     ["@semantic-release/github", {
       "assets": [


### PR DESCRIPTION
Prevents previously built jars from being uploaded with the release.